### PR TITLE
Don't require Foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,19 @@ let package = Package(
         .library(
             name: "GlassGem",
             targets: ["GlassGem"]),
+        .library(
+            name: "GlassGemFoundation",
+            targets: ["GlassGemFoundation"]),
     ],
     targets: [
         .target(
             name: "GlassGem",
             dependencies: []),
+        .target(
+            name: "GlassGemFoundation",
+            dependencies: ["GlassGem"]),
         .testTarget(
             name: "GlassGemTests",
-            dependencies: ["GlassGem"]),
+            dependencies: ["GlassGemFoundation"]),
     ]
 )

--- a/Sources/GlassGemFoundation/Data+COBS.swift
+++ b/Sources/GlassGemFoundation/Data+COBS.swift
@@ -1,0 +1,39 @@
+//
+//  Data+Cobs.swift
+//
+//  Created by Andrew R Madsen on 9/2/23.
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Andrew R. Madsen
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+import GlassGem
+
+public extension Data {
+    func encodedUsingCOBS() -> Data {
+        Data([UInt8](self).encodedUsingCOBS())
+    }
+
+    func decodedFromCOBS() -> [Data] {
+        [UInt8](self).decodedFromCOBS().map { Data($0) }
+    }
+}

--- a/Tests/GlassGemTests/GlassGemTests.swift
+++ b/Tests/GlassGemTests/GlassGemTests.swift
@@ -26,7 +26,7 @@
 //  SOFTWARE.
 
 import XCTest
-@testable import GlassGem
+@testable import GlassGemFoundation
 
 final class GlassGemTests: XCTestCase {
 


### PR DESCRIPTION
Separate out Data support into GlassGemFoundation; base library uses [UInt8].